### PR TITLE
Fix typo: skin.widgets uses "File" for filename+path, not "Path"

### DIFF
--- a/1080i/Includes_Shelf.xml
+++ b/1080i/Includes_Shelf.xml
@@ -473,83 +473,83 @@
         <content>
           <item id="1" description="Movies">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.1.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.1.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.1.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.1.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.1.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.1.File)])</onclick>
           </item>
           <item id="2" description="Shortcut2">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.2.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.2.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.2.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.2.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.2.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.2.File)])</onclick>
           </item>
           <item id="3" description="Shortcut3">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.3.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.3.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.3.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.3.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.3.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.3.File)])</onclick>
           </item>
           <item id="4" description="Shortcut4">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.4.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.4.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.4.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.4.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.4.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.4.File)])</onclick>
           </item>
           <item id="5" description="Shortcut5">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.5.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.5.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.5.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.5.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.5.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.5.File)])</onclick>
           </item>
           <item id="6" description="Movies">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.6.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.6.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.6.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.6.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.6.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.6.File)])</onclick>
           </item>
           <item id="7" description="Shortcut7">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.7.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.7.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.7.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.7.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.7.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.7.File)])</onclick>
           </item>
           <item id="8" description="Shortcut8">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.8.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.8.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.8.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.8.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.8.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.8.File)])</onclick>
           </item>
           <item id="9" description="Shortcut9">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.9.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.9.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.9.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.9.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.9.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.9.File)])</onclick>
           </item>
           <item id="10" description="Shortcut10">
             <visible>!Skin.HasSetting(MoviesShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentMovie.10.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentMovie.10.File))</visible>
             <label>$INFO[Window.Property(RecentMovie.10.Title)]</label>
             <thumb>$INFO[Window.Property(RecentMovie.10.Art(poster))]</thumb>
             <property name="ItemType">$LOCALIZE[20386]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.10.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMovie.10.File)])</onclick>
           </item>
           <item id="1" description="Addons">
             <visible>Skin.HasSetting(MoviesShelf_Custom)</visible>
@@ -683,103 +683,103 @@
         <content>
           <item id="1" description="Episodes1">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.1.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.1.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.1.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.1.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.1.Season),S,•]$INFO[Window.Property(RecentEpisode.1.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.1.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.1.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.1.File)])</onclick>
           </item>
           <item id="2" description="Shortcut2">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.2.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.2.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.2.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.2.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.2.Season),S,•]$INFO[Window.Property(RecentEpisode.2.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.2.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.2.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.2.File)])</onclick>
           </item>
           <item id="3" description="Shortcut3">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.3.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.3.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.3.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.3.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.3.Season),S,•]$INFO[Window.Property(RecentEpisode.3.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.3.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.3.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.3.File)])</onclick>
           </item>
           <item id="4" description="Shortcut4">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.4.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.4.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.4.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.4.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.4.Season),S,•]$INFO[Window.Property(RecentEpisode.4.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.4.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.4.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.4.File)])</onclick>
           </item>
           <item id="5" description="Shortcut5">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.5.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.5.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.5.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.5.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.5.Season),S,•]$INFO[Window.Property(RecentEpisode.5.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.5.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.5.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.5.File)])</onclick>
           </item>
           <item id="6" description="Shortcut6">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.6.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.6.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.6.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.6.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.6.Season),S,•]$INFO[Window.Property(RecentEpisode.6.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.6.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.6.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.6.File)])</onclick>
           </item>
           <item id="7" description="Shortcut7">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.7.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.7.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.7.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.7.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.7.Season),S,•]$INFO[Window.Property(RecentEpisode.7.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.7.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.7.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.7.File)])</onclick>
           </item>
           <item id="8" description="Shortcut8">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.8.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.8.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.8.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.8.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.8.Season),S,•]$INFO[Window.Property(RecentEpisode.8.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.8.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.8.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.8.File)])</onclick>
           </item>
           <item id="9" description="Shortcut9">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.9.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.9.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.9.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.9.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.9.Season),S,•]$INFO[Window.Property(RecentEpisode.9.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.9.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.9.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.9.File)])</onclick>
           </item>
           <item id="10" description="Shortcut10">
             <visible>!Skin.HasSetting(TVShelf_Custom)</visible>
-            <visible>!IsEmpty(Window.Property(RecentEpisode.10.Path))</visible>
+            <visible>!IsEmpty(Window.Property(RecentEpisode.10.File))</visible>
             <label>$INFO[Window.Property(RecentEpisode.10.Title)]</label>
             <label2>$INFO[Window.Property(RecentEpisode.10.TVshowTitle)]</label2>
             <property name="SeasonEpisode">$INFO[Window.Property(RecentEpisode.10.Season),S,•]$INFO[Window.Property(RecentEpisode.10.Episode),E]</property>
             <thumb>$INFO[Window.Property(RecentEpisode.10.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20387]</property>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.10.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentEpisode.10.File)])</onclick>
           </item>
           <item id="1" description="Addons">
             <visible>Skin.HasSetting(TVShelf_Custom)</visible>
@@ -1000,101 +1000,101 @@
           </item>
           <item id="1" description="Music Videos">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.1.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.1.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.1.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.1.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.1.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.1.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.1.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>
           <item id="2" description="Shortcut2">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.2.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.2.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.2.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.2.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.2.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.2.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.2.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>
           <item id="3" description="Shortcut3">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.3.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.3.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.3.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.3.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.3.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.3.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.3.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>
           <item id="4" description="Shortcut4">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.4.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.4.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.4.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.4.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.4.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.4.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.4.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>
           <item id="5" description="Shortcut5">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.5.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.5.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.5.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.5.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.5.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.5.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.5.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>
           <item id="6" description="Music">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.6.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.6.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.6.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.6.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.6.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.6.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.6.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>
           <item id="7" description="Shortcut7">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.7.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.7.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.7.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.7.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.7.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.7.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.7.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>
           <item id="8" description="Shortcut8">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.8.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.8.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.8.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.8.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.8.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.8.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.8.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>
           <item id="9" description="Shortcut9">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.9.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.9.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.9.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.9.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.9.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.9.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.9.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>
           <item id="10" description="Shortcut10">
             <visible>!Skin.HasSetting(MusicShelf_Custom)</visible>
-            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.10.Path))</visible>
+            <visible>!IsEmpty(Window(Home).Property(RecentMusicVideo.10.File))</visible>
             <label>$INFO[Window(Home).Property(RecentMusicVideo.10.Title)]</label>
             <label2>$INFO[Window(Home).Property(RecentMusicVideo.10.Artist)]</label2>
             <onclick>PlayList.Clear</onclick>
-            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.10.Path)])</onclick>
+            <onclick>PlayMedia($ESCINFO[Window(Home).Property(RecentMusicVideo.10.File)])</onclick>
             <thumb>$INFO[Window(Home).Property(RecentMusicVideo.10.Art(thumb))]</thumb>
             <property name="ItemType">$LOCALIZE[20390]</property>
           </item>


### PR DESCRIPTION
media shelf items did not play when clicking them.
this was due to a different naming convention in skin.widgets than in the core "Latest" item list
