### PR TITLE
Not all language have "&" symbol. Use "and" word

### DIFF
--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -343,7 +343,7 @@
           </control>
           <control type="button" id="704">
             <include>9000Buttons</include>
-            <label>$LOCALIZE[292] &amp; $LOCALIZE[287]</label>
+            <label>$LOCALIZE[292] $LOCALIZE[1397] $LOCALIZE[287]</label>
             <onclick>ActivateWindow(OSDAudioSettings)</onclick>
           </control>
           <control type="button" id="705">


### PR DESCRIPTION
Better to use equivalent localization for "&" symbol. "and" word better
for that place.
