### PR TITLE
move pvr info down to fix overlapping

### DIFF
--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -56,7 +56,7 @@
         <label>-</label>
       </control>
       <control type="group">
-        <posy>114</posy>
+        <posy>165</posy>
         <visible>VideoPlayer.Content(LiveTV)</visible>
         <control type="label" description="Backend">
           <posx>60</posx>


### PR DESCRIPTION
this fixes the text overlap between the codec information and the pvr addon information while watching livetv and fits it back to it's correct area.

before: http://s3.postimg.org/u49jm1prn/screenshot002.png
after:    http://s3.postimg.org/y21ep71yr/screenshot004.png
